### PR TITLE
Convert backend to FastAPI and add Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+*.py[cod]
+venv
+backend/.env
+backend/node_modules
+frontend/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+# install node
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend ./backend
+COPY frontend/package.json ./frontend/package.json
+RUN npm --prefix frontend install
+COPY frontend ./frontend
+RUN npm --prefix frontend run build
+
+EXPOSE 8000 3000
+
+CMD uvicorn backend.main:app --host 0.0.0.0 --port 8000 & npm --prefix frontend start

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # edu-ai-mpact
-LearnZp
+
+This project provides a minimal FastAPI backend and a Next.js frontend. The backend calls OpenRouter models through the OpenAI client.
+
+## Requirements
+- Python 3.12
+- Node.js 18+
+
+## Setup
+Install Python and Node dependencies:
+
+```bash
+python3.12 -m pip install -r requirements.txt
+npm --prefix frontend install
+```
+
+Create an environment variable `OPENROUTER_API_KEY` with your API key.
+
+## Running locally
+Start the backend:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+In another terminal start the frontend:
+
+```bash
+npm --prefix frontend run dev
+```
+
+The site will be available at `http://localhost:3000`.
+
+## Docker
+A single Dockerfile builds and runs both services:
+
+```bash
+docker build -t edu-ai-mpact .
+docker run -p 3000:3000 -p 8000:8000 -e OPENROUTER_API_KEY=sk-... edu-ai-mpact
+```
+
+## Testing
+Run tests using `pytest`:
+
+```bash
+python3.12 -m pytest
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,29 @@
+import os
+from fastapi import FastAPI, Depends, HTTPException
+from pydantic import BaseModel
+from openai import AsyncOpenAI
+
+app = FastAPI(title="Edu AI Mpact")
+
+class ChatRequest(BaseModel):
+    message: str
+
+class ChatResponse(BaseModel):
+    response: str
+
+async def get_client() -> AsyncOpenAI:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY not set")
+    return AsyncOpenAI(api_key=api_key, base_url="https://openrouter.ai/api/v1")
+
+@app.post("/api/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest, client: AsyncOpenAI = Depends(get_client)):
+    try:
+        completion = await client.chat.completions.create(
+            model="openrouter/auto",
+            messages=[{"role": "user", "content": req.message}]
+        )
+        return {"response": completion.choices[0].message.content}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "edu-ai-mpact-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [message, setMessage] = useState('');
+  const [response, setResponse] = useState('');
+
+  const send = async () => {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+    const data = await res.json();
+    setResponse(data.response || data.detail);
+  };
+
+  return (
+    <main style={{ maxWidth: 600, margin: '2rem auto', fontFamily: 'Arial' }}>
+      <h1>Edu AI Mpact</h1>
+      <textarea
+        style={{ width: '100%', height: 120 }}
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+      />
+      <button onClick={send} style={{ marginTop: '0.5rem' }}>Send</button>
+      <pre style={{ background: '#f1f1f1', padding: '1rem' }}>{response}</pre>
+    </main>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+openai
+uvicorn
+pytest
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app, get_client
+
+class DummyCompletions:
+    async def create(self, model: str, messages):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))])
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyCompletions()
+
+class DummyClient:
+    def __init__(self):
+        self.chat = DummyChat()
+
+@pytest.fixture(autouse=True)
+def override_client():
+    app.dependency_overrides[get_client] = lambda: DummyClient()
+    yield
+    app.dependency_overrides.clear()
+
+def test_chat_endpoint():
+    client = TestClient(app)
+    resp = client.post("/api/chat", json={"message": "Hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "hi"}


### PR DESCRIPTION
## Summary
- replace Node backend with FastAPI implementation
- create a minimal Next.js frontend
- add Dockerfile to run both services in one container
- revise requirements and .gitignore
- update tests to use FastAPI TestClient
- document setup and usage in README

## Testing
- `python3.12 -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684c8c7aa8e0833085d141f8dc3a5ee3